### PR TITLE
Adding npm installation option

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,10 +6,11 @@ Make d3 data functions use promises instead of callbacks
 This library uses ES6 Promise. (http://www.html5rocks.com/en/tutorials/es6/promises/)
 To bring browsers that lack a complete promises implementation up to spec compliance, or add promises to other browsers and Node.js, check out the [polyfill](https://github.com/jakearchibald/ES6-Promises#readme) (2k gzipped).
 
-### Installation
+### Installation options
 
 ```
 bower install d3.promise
+npm install d3.promise
 ```
 
 This library can be imported using standard `<script>` as well as AMD (such as RequireJS).

--- a/package.json
+++ b/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "d3.promise",
+  "version": "0.2.1",
+  "description": "d3.csv & friends that return promises instead of accepting callbacks",
+  "license": "Apache v2",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/kristw/d3.promise"
+  },
+  "homepage": "https://github.com/kristw/d3.promise",
+  "keywords": [
+    "d3.promise",
+    "d3"
+  ],
+  "dependencies": {
+    "d3": "~3.4.6"
+  }
+}


### PR DESCRIPTION
Adding a `package.json` with the same configuration as bower, to be able to easily publish to npm.

I'd like to avoid bringing in bower to projects where I'm only currently using npm to manage my dependencies.
